### PR TITLE
Lower minumum swift and iOS versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,9 +7,9 @@ let package = Package(
     name: "Epic",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13),
-        .tvOS(.v13),
-        .watchOS(.v6)
+        .iOS(.v12),
+        .tvOS(.v12),
+        .watchOS(.v5)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
## Summary
Lower the required SDK and Swift language versions.
It was an artificial requirement since this project can work with lower versions providing they support Xcode 12.