### PR TITLE
Add iOS 11 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,9 @@ let package = Package(
     name: "Epic",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v12),
-        .tvOS(.v12),
-        .watchOS(.v5)
+        .iOS(.v11),
+        .tvOS(.v11),
+        .watchOS(.v4) 
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
After a few tests (and suggestions), I've noticed that the minimum versions for this framework can be updated to work one step lower. I love this framework, and my team does too, and we'd love to continue using it with Swift Package Manager. Consider allowing us to bump the minimum version?