### PR TITLE
Make throttle blocks non optional

### DIFF
--- a/Sources/Epic/Protocols/ThrottleProtocol.swift
+++ b/Sources/Epic/Protocols/ThrottleProtocol.swift
@@ -7,5 +7,5 @@ import Foundation
 protocol ThrottleProtocol {
     init(interval: TimeInterval)
 
-    func throttle(block: (() -> Void)?)
+    func throttle(block: @escaping (() -> Void))
 }

--- a/Sources/Epic/Throttle.swift
+++ b/Sources/Epic/Throttle.swift
@@ -17,12 +17,12 @@ public final class Throttle: ThrottleProtocol {
     }
 
     /// Throttles a block that will be only executed if no later requests are sent within the specified interval of time (100 milliseconds by default)
-    public func throttle(block: EpicBlock?) {
+    public func throttle(block: @escaping EpicBlock) {
         self.task.cancel()
         self.task = DispatchWorkItem() { [weak self] in
             self?.previousExecution = Date()
             DispatchQueue.main.async {
-                block?()
+                block()
             }
         }
         let delay = Me.second(from: self.previousExecution) > self.interval ? 0 : self.interval


### PR DESCRIPTION
## Summary
Throttle blocks should not be optional since there is no point on throttling an inexistent operation.