### PR TITLE
Use a Combine method if available

### DIFF
--- a/Sources/Epic/ScheduledThrottle.swift
+++ b/Sources/Epic/ScheduledThrottle.swift
@@ -1,0 +1,76 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+#if canImport(Combine)
+public typealias FutureOperation = Future<EpicBlock, Never>
+
+/**
+ Publishes the first and most-recent block published by the upstream publisher
+ in the specified time interval.
+
+ Overwrite `usesLatest` to prevent the most-recent block from being executed.
+ */
+public final class ThrottleScheduledBy<S: Scheduler> {
+
+    /// A Boolean value that indicates whether to publish the most recent element. If false, the publisher emits the first element received during the interval.
+    public var usesLatest: Bool = true
+
+    public private(set) var interval: S.SchedulerTimeType.Stride
+    private var blockCancellable: AnyCancellable?
+    @Published private var operations = [FutureOperation]()
+    public let scheduler: S
+
+    public init(
+        interval: S.SchedulerTimeType.Stride,
+        scheduler: S
+    ) {
+        self.interval = interval
+        self.scheduler = scheduler
+    }
+
+    /// Throttles a block that will be only executed if no later requests are sent within the specified interval of time
+    public func throttle(block: @escaping () -> Void) {
+        let futureOperation = FutureOperation { callback in
+            callback(.success(block))
+        }
+        self.throttle(futureOperation: futureOperation)
+    }
+
+    /// Throttles a promise block that will be only executed if no later requests are sent within the specified interval of time
+    public func throttle(futureOperation: FutureOperation) {
+        initializeThrottling()
+        operations.append(futureOperation)
+    }
+
+    /// Starts throttling with a cancellable subscriber.
+    /// It will only initialize a cancellable subscriber if the current one is nil.
+    private func initializeThrottling() {
+        if blockCancellable == nil { // Delays throttle publishing until its first execution
+            blockCancellable = startThrottling(
+                usesLatest: usesLatest,
+                scheduler: scheduler
+            )
+        }
+    }
+
+    /// Creates a cancellable subscriber to blocks appended to the operations variable.
+    private func startThrottling(
+        usesLatest: Bool,
+        scheduler: S
+    ) -> AnyCancellable {
+        $operations
+            .throttle(
+                for: 1,
+                scheduler: scheduler,
+                latest: usesLatest
+            )
+            .compactMap(\.last)
+            .sink { [weak self] result in
+                //                result()
+                self?.operations.removeAll()
+            }
+    }
+}
+#endif

--- a/Sources/Epic/Throttle.swift
+++ b/Sources/Epic/Throttle.swift
@@ -1,62 +1,10 @@
 import Foundation
-#if canImport(Combine)
-import Combine
-#endif
-
-#if canImport(Combine)
-/**
- Publishes the first and most-recent block published by the upstream publisher
- in the specified time interval.
- 
- Overwrite `usesLatest` to prevent the most-recent block from being executed.
- */
-public final class Throttle: ThrottleProtocol {
-    /// A Boolean value that indicates whether to publish the most recent element. If false, the publisher emits the first element received during the interval.
-    public var usesLatest: Bool = true
-    
-    private var interval: TimeInterval
-    private var blockCancellable: AnyCancellable?
-    @Published private var operations = [EpicBlock]()
-    
-    /// Initializes with the interval of seconds within tasks are constrained to be executed
-    /// Defaults to 1 second.
-    public init(interval: TimeInterval = 1) {
-        self.interval = interval
-    }
-    
-    /// Throttles a block that will be only executed if no later requests are sent within the specified interval of time
-    public func throttle(block: @escaping () -> Void) {
-        if self.blockCancellable == nil { // Delays throttle publishing until its first execution
-            self.blockCancellable = startThrottling(
-                scheduler: .main,
-                usesLatest: self.usesLatest
-            )
-        }
-        self.operations.append(block)
-    }
-    
-    /// Creates a cancellable subscriber to blocks appended to the operations variable.
-    private func startThrottling(scheduler: RunLoop, usesLatest: Bool) -> AnyCancellable {
-        self.$operations
-            .throttle(
-                for: RunLoop.SchedulerTimeType.Stride(self.interval),
-                scheduler: scheduler,
-                latest: usesLatest
-            )
-            .compactMap(\.last)
-            .sink { [weak self] lastBlock in
-                lastBlock()
-                self?.operations.removeAll()
-            }
-    }
-}
-#else
 
 /// Throttles tasks within time intervals.
 /// Within every interval, only the last throttled task will be executed.
 /// Tasks are always dispatched on the main queue.
 public final class Throttle: ThrottleProtocol {
-    private let queue: DispatchQueue = DispatchQueue.global(qos: .background)
+    private var queue: DispatchQueue
     private var task: DispatchWorkItem = DispatchWorkItem(block: {})
     private var previousExecution: Date = Date.distantPast
     private var interval: TimeInterval
@@ -64,16 +12,17 @@ public final class Throttle: ThrottleProtocol {
     /// Initializes with the interval of seconds within tasks are constrained to be executed
     public init(interval: TimeInterval = 1) {
         self.interval = interval
+        self.queue = DispatchQueue.global(qos: .background)
     }
 
     /// Throttles a block that will be only executed if no later requests are sent within the specified interval of time (100 milliseconds by default)
     public func throttle(block: @escaping EpicBlock) {
-        self.throttle(block: block, onQueue: .main)
+        self.throttle(block: block, onQueue: self.queue)
     }
 
     private func throttle(
         block: @escaping EpicBlock,
-        onQueue queue: DispatchQueue = .main
+        onQueue queue: DispatchQueue
     ) {
         self.task.cancel()
         self.task = DispatchWorkItem() { [weak self] in
@@ -96,4 +45,3 @@ public final class Throttle: ThrottleProtocol {
         return now.timeIntervalSince(referenceDate)
     }
 }
-#endif

--- a/Tests/Schedulers/DispatchQueue+Extensions.swift
+++ b/Tests/Schedulers/DispatchQueue+Extensions.swift
@@ -1,0 +1,16 @@
+#if canImport(Combine)
+import Combine
+import Foundation
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension DispatchQueue {
+    typealias TestableScheduler = Testable.SchedulerUsing<DispatchQueue>
+    /// A scheduler for testing purposes for `DispatchQueue` schedulers.
+    public static var testableScheduler: Testable.SchedulerUsing<DispatchQueue> {
+        let dispatchTime = DispatchTime(uptimeNanoseconds: 1)
+        let scheduler = SchedulerTimeType(dispatchTime)
+        return .init(now: scheduler)
+    }
+}
+
+#endif

--- a/Tests/Schedulers/PFTestScheduler.swift
+++ b/Tests/Schedulers/PFTestScheduler.swift
@@ -1,0 +1,209 @@
+#if canImport(Combine)
+import Combine
+import Foundation
+
+/// A scheduler whose current time and execution can be controlled in a deterministic manner.
+///
+/// This scheduler is useful for testing how the flow of time effects publishers that use
+/// asynchronous operators, such as `debounce`, `throttle`, `delay`, `timeout`, `receive(on:)`,
+/// `subscribe(on:)` and more.
+///
+/// For example, consider the following `race` operator that runs two futures in parallel, but
+/// only emits the first one that completes:
+///
+///     func race<Output, Failure: Error>(
+///       _ first: Future<Output, Failure>,
+///       _ second: Future<Output, Failure>
+///     ) -> AnyPublisher<Output, Failure> {
+///       first
+///         .merge(with: second)
+///         .prefix(1)
+///         .eraseToAnyPublisher()
+///     }
+///
+/// Although this publisher is quite simple we may still want to write some tests for it.
+///
+/// To do this we can create a test scheduler and create two futures, one that emits after a
+/// second and one that emits after two seconds:
+///
+///     let scheduler = DispatchQueue.test
+///     let first = Future<Int, Never> { callback in
+///       scheduler.schedule(after: scheduler.now.advanced(by: 1)) { callback(.success(1)) }
+///     }
+///     let second = Future<Int, Never> { callback in
+///       scheduler.schedule(after: scheduler.now.advanced(by: 2)) { callback(.success(2)) }
+///     }
+///
+/// And then we can race these futures and collect their emissions into an array:
+///
+///     var output: [Int] = []
+///     let cancellable = race(first, second).sink { output.append($0) }
+///
+/// And then we can deterministically move time forward in the scheduler to see how the publisher
+/// emits. We can start by moving time forward by one second:
+///
+///     scheduler.advance(by: 1)
+///     XCTAssertEqual(output, [1])
+///
+/// This proves that we get the first emission from the publisher since one second of time has
+/// passed. If we further advance by one more second we can prove that we do not get anymore
+/// emissions:
+///
+///     scheduler.advance(by: 1)
+///     XCTAssertEqual(output, [1])
+///
+/// This is a very simple example of how to control the flow of time with the test scheduler,
+/// but this technique can be used to test any publisher that involves Combine's asynchronous
+/// operations.
+///
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+public final class PFTestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
+where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
+
+    private var lastSequence: UInt = 0
+    public let minimumTolerance: SchedulerTimeType.Stride = .zero
+    public private(set) var now: SchedulerTimeType
+    private var scheduled: [(sequence: UInt, date: SchedulerTimeType, action: () -> Void)] = []
+
+    /// Creates a test scheduler with the given date.
+    ///
+    /// - Parameter now: The current date of the test scheduler.
+    public init(now: SchedulerTimeType) {
+        self.now = now
+    }
+
+    /// Advances the scheduler by the given stride.
+    ///
+    /// - Parameter stride: A stride. By default this argument is `.zero`, which does not advance the
+    ///   scheduler's time but does cause the scheduler to execute any units of work that are waiting
+    ///   to be performed for right now.
+    public func advance(by stride: SchedulerTimeType.Stride = .zero) {
+        let finalDate = self.now.advanced(by: stride)
+
+        while self.now <= finalDate {
+            self.scheduled.sort { ($0.date, $0.sequence) < ($1.date, $1.sequence) }
+
+            guard
+                let nextDate = self.scheduled.first?.date,
+                finalDate >= nextDate
+            else {
+                self.now = finalDate
+                return
+            }
+
+            self.now = nextDate
+
+            while let (_, date, action) = self.scheduled.first, date == nextDate {
+                self.scheduled.removeFirst()
+                action()
+            }
+        }
+    }
+
+    /// Runs the scheduler until it has no scheduled items left.
+    ///
+    /// This method is useful for proving exhaustively that your publisher eventually completes
+    /// and does not run forever. For example, the following code will run an infinite loop forever
+    /// because the timer never finishes:
+    ///
+    ///     let scheduler = DispatchQueue.test
+    ///     Publishers.Timer(every: .seconds(1), scheduler: scheduler)
+    ///       .autoconnect()
+    ///       .sink { _ in print($0) }
+    ///       .store(in: &cancellables)
+    ///
+    ///     scheduler.run() // Will never complete
+    ///
+    /// If you wanted to make sure that this publisher eventually completes you would need to
+    /// chain on another operator that completes it when a certain condition is met. This can be
+    /// done in many ways, such as using `prefix`:
+    ///
+    ///     let scheduler = DispatchQueue.test
+    ///     Publishers.Timer(every: .seconds(1), scheduler: scheduler)
+    ///       .autoconnect()
+    ///       .prefix(3)
+    ///       .sink { _ in print($0) }
+    ///       .store(in: &cancellables)
+    ///
+    ///     scheduler.run() // Prints 3 times and completes.
+    ///
+    public func run() {
+        while let date = self.scheduled.first?.date {
+            self.advance(by: self.now.distance(to: date))
+        }
+    }
+
+    public func schedule(
+        after date: SchedulerTimeType,
+        interval: SchedulerTimeType.Stride,
+        tolerance _: SchedulerTimeType.Stride,
+        options _: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) -> Cancellable {
+        let sequence = self.nextSequence()
+
+        func scheduleAction(for date: SchedulerTimeType) -> () -> Void {
+            return { [weak self] in
+                let nextDate = date.advanced(by: interval)
+                self?.scheduled.append((sequence, nextDate, scheduleAction(for: nextDate)))
+                action()
+            }
+        }
+
+        self.scheduled.append((sequence, date, scheduleAction(for: date)))
+
+        return AnyCancellable { [weak self] in
+            self?.scheduled.removeAll(where: { $0.sequence == sequence })
+        }
+    }
+
+    public func schedule(
+        after date: SchedulerTimeType,
+        tolerance _: SchedulerTimeType.Stride,
+        options _: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) {
+        self.scheduled.append((self.nextSequence(), date, action))
+    }
+
+    public func schedule(options _: SchedulerOptions?, _ action: @escaping () -> Void) {
+        self.scheduled.append((self.nextSequence(), self.now, action))
+    }
+
+    private func nextSequence() -> UInt {
+        self.lastSequence += 1
+        return self.lastSequence
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension DispatchQueue {
+    /// A test scheduler of dispatch queues.
+    public static var test: TestSchedulerOf<DispatchQueue> {
+        // NB: `DispatchTime(uptimeNanoseconds: 0) == .now())`. Use `1` for consistency.
+        .init(now: .init(.init(uptimeNanoseconds: 1)))
+    }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension OperationQueue {
+    /// A test scheduler of operation queues.
+    public static var test: TestSchedulerOf<OperationQueue> {
+        .init(now: .init(.init(timeIntervalSince1970: 0)))
+    }
+}
+
+extension RunLoop {
+    /// A test scheduler of run loops.
+    public static var test: TestSchedulerOf<RunLoop> {
+        .init(now: .init(.init(timeIntervalSince1970: 0)))
+    }
+}
+
+/// A convenience type to specify a `TestScheduler` by the scheduler it wraps rather than by the
+/// time type and options type.
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+public typealias TestSchedulerOf<Scheduler> = PFTestScheduler<
+    Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
+> where Scheduler: Combine.Scheduler
+#endif

--- a/Tests/Schedulers/TestScheduler.swift
+++ b/Tests/Schedulers/TestScheduler.swift
@@ -1,0 +1,150 @@
+#if canImport(Combine)
+import Combine
+
+public final class TestScheduler<SchedulerTimeType, SchedulerOptions>: Scheduler
+where SchedulerTimeType: Strideable, SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible
+{
+    typealias ScheduledItem = (UInt, SchedulerTimeType, () -> Void)
+
+    public private(set) var now: SchedulerTimeType
+
+    public private(set) var minimumTolerance: SchedulerTimeType.Stride = .zero
+
+    /// The sequence of items to be dispatched
+    private var scheduled: [(
+        sequenceIndex: UInt,
+        date: SchedulerTimeType,
+        action: () -> Void
+    )] = []
+
+    /// Keeps the internal index of the last disptached item
+    private var previousSequenceIndex: UInt = 0
+
+    // MARK: Init
+
+    /// Creates a test scheduler with the given date.
+    ///
+    /// - Parameter now: The current date of the test scheduler.
+    public init(now: SchedulerTimeType) {
+        self.now = now
+    }
+
+    // MARK: Protocol conformace
+
+    /// Performs the action at the next possible opportunity.
+    public func schedule(
+        options: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) {
+        self.scheduled.append(
+            Self.scheduledItem(
+                index: self.nextSequenceIndex(),
+                date: self.now,
+                action: action
+            )
+        )
+    }
+
+    /// Performs the action at some time after the specified date.
+    public func schedule(
+        after date: SchedulerTimeType,
+        tolerance: SchedulerTimeType.Stride,
+        options: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) {
+        self.scheduled.append(
+            Self.scheduledItem(
+                index: self.nextSequenceIndex(),
+                date: date,
+                action: action
+            )
+        )
+    }
+
+    /// Performs the action at some time after the specified date, at the specified frequency, optionally taking into account tolerance if possible.
+    public func schedule(
+        after date: SchedulerTimeType,
+        interval: SchedulerTimeType.Stride,
+        tolerance: SchedulerTimeType.Stride,
+        options: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) -> Cancellable {
+        let sequenceIndex = self.nextSequenceIndex()
+
+        func scheduleAction(for date: SchedulerTimeType) -> () -> Void {
+            return { [weak self] in
+                let nextDate = date.advanced(by: interval)
+                self?.scheduled.append(
+                    Self.scheduledItem(
+                        index: sequenceIndex,
+                        date: nextDate,
+                        action: scheduleAction(for: nextDate)
+                    )
+                )
+                action()
+            }
+        }
+
+        self.scheduled.append(
+            Self.scheduledItem(
+                index: sequenceIndex,
+                date: date,
+                action: scheduleAction(for: date)
+            )
+        )
+
+        return AnyCancellable { [weak self] in
+            self?.scheduled.removeAll(where: { $0.sequenceIndex == sequenceIndex })
+        }
+    }
+
+    public func run() {
+        while let date = self.scheduled.first?.date {
+            self.advance(by: self.now.distance(to: date))
+        }
+    }
+
+    public func advance(by stride: SchedulerTimeType.Stride = .zero) {
+        let finalDate = self.now.advanced(by: stride)
+
+        while self.now <= finalDate {
+            self.scheduled.sort { ($0.date, $0.sequenceIndex) < ($1.date, $1.sequenceIndex) }
+
+            guard
+                let nextDate = self.scheduled.first?.date,
+                finalDate >= nextDate
+            else {
+                self.now = finalDate
+                return
+            }
+
+            self.now = nextDate
+
+            while let (_, date, action) = self.scheduled.first, date == nextDate {
+                self.scheduled.removeFirst()
+                action()
+            }
+        }
+    }
+
+    // MARK: Private
+
+    /// Returns a ScheduledItem (a tuple).
+    private static func scheduledItem(
+        index: UInt,
+        date: SchedulerTimeType,
+        action: @escaping () -> Void
+    ) -> ScheduledItem {
+        (index, date, action)
+    }
+
+    /// Updates the internal `previousSequenceIndex` index
+    /// - Returns: The next sequence index.
+    ///     This index could also be retrieved by accessing `previousSequenceIndex`.
+    private func nextSequenceIndex() -> UInt {
+        self.previousSequenceIndex += 1
+        return self.previousSequenceIndex
+    }
+}
+
+#endif

--- a/Tests/Schedulers/Testable.swift
+++ b/Tests/Schedulers/Testable.swift
@@ -1,0 +1,13 @@
+#if canImport(Combine)
+import Combine
+#endif
+
+public struct Testable {
+    #if canImport(Combine)
+    /// Represents a Scheduler type with an associated type and options the original scheduler wraps.
+    /// Use it as `Testable.SchedulerUsing<DispatchQueue>`.
+    public typealias SchedulerUsing<Scheduler> = TestScheduler<
+        Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
+    > where Scheduler: Combine.Scheduler
+    #endif
+}

--- a/Tests/ThrottleTests.swift
+++ b/Tests/ThrottleTests.swift
@@ -1,6 +1,97 @@
 import XCTest
 import Epic
 
+#if canImport(Combine)
+import Combine
+
+class ThrottleTests: XCTestCase {
+    let queue = DispatchQueue(label: "test queue")
+
+    /**
+     * Three tasks are executed in a maximum window of 200 milliseconds.
+     * All three are throttled every 100 milliseconds, which allows only two tasks to enter execution.
+     * i.e: a user types a new character every 100 milliseconds and we only want to dispatch a query every 200 at much.
+     */
+    func testThrottleMultipleTasksButExecutesTheFirstAndTheLastOneOnly() {
+        let dispatcher = TestDispatcher()
+        let epic = ThrottleScheduledBy(
+            interval: 1,
+            scheduler: dispatcher.scheduler
+        )
+
+        var executedTasks = [Int]()
+
+        let firstOperation = dispatcher.schedule(after: 0.1, block: {
+            executedTasks.append(0)
+        })
+        let secondOperation = dispatcher.schedule(after: 0.11, block: {
+            executedTasks.append(1)
+        })
+        let thirdOperation = dispatcher.schedule(after: 0.12, block: {
+            executedTasks.append(2)
+        })
+        epic.throttle(futureOperation: firstOperation)
+        epic.throttle(futureOperation: secondOperation)
+        epic.throttle(futureOperation: thirdOperation)
+
+        XCTAssertEqual(executedTasks, [0, 2])
+    }
+
+    func testCombineThrottle() {
+        let scheduler = DispatchQueue.testableScheduler
+        var executedTasks = [Int]()
+        var enqueued = [Future<Int, Never>]()
+        let cancellable = enqueued.publisher
+            .throttle(for: 0, scheduler: DispatchQueue.main, latest: false)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { subscriber in print(subscriber) },
+                receiveValue: { value in print(value) }
+            )
+
+        enqueued.append(Future { promise in
+//            scheduler.schedule(after: scheduler.now.advanced(by: 1)) {
+//                promise(.success(0))
+//            }
+            promise(.success(0))
+        })
+        enqueued.append(Future { promise in
+//            scheduler.schedule(after: scheduler.now.advanced(by: 1)) {
+//                promise(.success(1))
+//            }
+            promise(.success(1))
+        })
+        enqueued.append(Future { promise in
+//            scheduler.schedule(after: scheduler.now.advanced(by: 1)) {
+//                promise(.success(2))
+//            }
+            promise(.success(2))
+        })
+
+        XCTAssertEqual(executedTasks, [0, 2])
+    }
+}
+
+struct TestDispatcher {
+    let scheduler = DispatchQueue.testableScheduler
+
+    func schedule(
+        after: DispatchQueue.SchedulerTimeType.Stride,
+        block: @escaping () -> Void
+    ) -> FutureOperation {
+        return FutureOperation { callback in
+            scheduler.schedule(after: scheduler.now.advanced(by: after)) {
+                callback(.success(block))
+            }
+            callback(.success(block))
+        }
+    }
+}
+
+#else
+/**
+ Legacy version tests with no schedulers.
+ */
 class ThrottleTests: XCTestCase {
     func testThrottleWorksWithASingleTask() {
         let epic = Throttle()
@@ -56,3 +147,5 @@ class ThrottleTests: XCTestCase {
         })
     }
 }
+
+#endif


### PR DESCRIPTION
## Summary
Combine already includes a Throttle, which is already a better and more reliable version than the one that is included in Epic.
In favour of the external library deprecation, I would recommend using the Combine version if possible.
For those clients that may or not build for iOS 13 as the minimum deployment SDK, you can still use the Epic throttle as you used to.

### Breaking changes
None. The legacy throttle will work as before, but clients that include Combine will use the Combine version instead under the hood.
No changes must be applied to any project.